### PR TITLE
Add log URL Request at sessionMiddleware

### DIFF
--- a/server.go
+++ b/server.go
@@ -65,7 +65,7 @@ func clearSessionHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	devMode = os.Getenv("DEV_MODE") == "true" // TODO: mungkin akan kepakai
 
-	initFirebaseAdmin()
+	//initFirebaseAdmin()
 	precompileTemplate()
 	r := mux.NewRouter()
 
@@ -294,7 +294,7 @@ func GetSessionValue(session *sessions.Session, key string) interface{} {
 // TODO kenapa ssession middleware dan routenya sptnya dipanggil 2x?
 func sessionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Println("SessionMW")
+		log.Println("SessionMW URL : ", r.URL.String())
 		session, err := store.Get(r, "session-name")
 		if err != nil {
 			http.Error(w, "Gagal mendapatkan session", http.StatusInternalServerError)
@@ -350,6 +350,7 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 		TimeStamp  time.Time
 	}{
 		IsLoggedIn: GetSessionValue(session, "isLoggedIn").(bool),
+		//IsLoggedIn: false,
 		DevMode:    devMode,
 		Name:       GetSessionValue(session, "user_name").(string),
 		Email:      GetSessionValue(session, "user_email").(string),

--- a/static/base.html
+++ b/static/base.html
@@ -10,8 +10,8 @@
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"/>
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
-    {{ if .DevMode }}
-        <link href="style/global.css?v={{ .TimeStamp}}" rel="stylesheet">
+    {{ if .Base.DevMode }}
+        <link href="style/global.css?v={{ .Base.TimeStamp}}" rel="stylesheet">
     {{ else }}
         <link href="style/global.css" rel="stylesheet">
     {{ end }}
@@ -30,10 +30,10 @@
         </div>-->
       <div id="mobileMenu" class="md:hidden relative">
           <button id="menuButton" class="text-white hover:text-gray-200 focus:outline-none flex items-center">
-            {{ if not .IsLoggedIn}}
+            {{ if not .Base.IsLoggedIn}}
               <img src="https://via.placeholder.com/20" alt="Avatar" class="rounded-full" /> <!-- Ganti URL gambar sesuai kebutuhan -->
             {{ else }}
-              <img src="{{ .Photo}}" alt="Avatar" class="rounded-full w-5 h-5" /> <!-- Ganti URL gambar sesuai kebutuhan -->
+              <img src="{{ .Base.Photo}}" alt="Avatar" class="rounded-full w-5 h-5" /> <!-- Ganti URL gambar sesuai kebutuhan -->
             {{ end }}
           </button>
           <!-- Menu Popup -->
@@ -121,7 +121,7 @@ document.addEventListener('click', function(event) {
 </div>
 
 <div id="content" class="p-5">
-{{template "content" .}}
+    {{ .Content}}
 </div>
 
 <!-- Footer -->

--- a/static/daftar.html
+++ b/static/daftar.html
@@ -1,4 +1,3 @@
-{{ define "content" }}
 <div class="flex flex-col items-center justify-center h-auto">
       <h2 class="text-4xl font-bold mb-2 p-2 mt-2 tracking-tight text-gray-900
                   sm:text-2xl rwid-bold">Tuntaskan risetmu sebelum mendaftar ke
@@ -218,4 +217,3 @@
         {{ end }}
       {{end}}
   </div>
-{{ end }}

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,3 @@
-{{template "base.html" .}}
-{{define "content"}}
 <div class="flex flex-col items-center justify-center h-auto">
       <h2 class="text-4xl font-bold mb-2 p-2 mt-2 tracking-tight text-gray-900 sm:text-2xl rwid-bold">Kerja dari rumah bergaji dollar?</h2>        
       <p class="text-gray-600 text-lg  leading-8 mb-8 p-2 text-justify text-gray-600" >Pelajari course upgrade skill yang sesuai untukmu sampai kamu menembus remote work bersama kami! Berlaku juga untuk <b class="rwid-bold">2 anggota keluargamu</b> dimana tiap anggota keluarga bisa mempelajari course yang berbeda. Tanpa tambahan biaya! <b class="rwid-bold">Lifetime.</b></p>
@@ -200,4 +198,3 @@
       </div>
     </div>
   </div>
-{{ end }}


### PR DESCRIPTION
The session middleware appears to be called twice because there is no URL information provided after the log URL is added. It can be ensured that the session middleware is not called twice.